### PR TITLE
Provide pre-built binaries on release creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  workflow_call:
+  pull_request:
+  push:
+    branches-ignore:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build ${{ matrix.goos }}-${{ matrix.goarch }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+            ext: ""
+          - goos: linux
+            goarch: arm64
+            ext: ""
+          - goos: darwin
+            goarch: amd64
+            ext: ""
+          - goos: darwin
+            goarch: arm64
+            ext: ""
+          - goos: windows
+            goarch: amd64
+            ext: ".exe"
+          - goos: windows
+            goarch: arm64
+            ext: ".exe"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build binary
+        env:
+          CGO_ENABLED: "0"
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          mkdir -p dist
+          go build -trimpath -ldflags="-s -w" -o "dist/winsysroot-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }}" .
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: winsysroot-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: dist/winsysroot-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,53 @@
+name: Publish Master Release
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit
+
+  publish-master-release:
+    name: Publish binaries for master
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Create or update release and upload assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          TAG="master-${GITHUB_SHA}"
+          ASSETS=(
+            dist/winsysroot-linux-amd64
+            dist/winsysroot-linux-arm64
+            dist/winsysroot-darwin-amd64
+            dist/winsysroot-darwin-arm64
+            dist/winsysroot-windows-amd64.exe
+            dist/winsysroot-windows-arm64.exe
+          )
+
+          if gh release view "$TAG" --repo "$GH_REPO" >/dev/null 2>&1; then
+            gh release upload "$TAG" --repo "$GH_REPO" "${ASSETS[@]}" --clobber
+          else
+            gh release create "$TAG" \
+              --repo "$GH_REPO" \
+              --target "$GITHUB_SHA" \
+              --title "master-${GITHUB_SHA}" \
+              --notes "Automated release for commit ${GITHUB_SHA} on master." \
+              "${ASSETS[@]}"
+          fi

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,10 @@
 module git.dolansoft.org/lorenz/winsysroot
 
-go 1.16
+go 1.22
 
 require (
 	github.com/klauspost/compress v1.15.6
 	github.com/richardlehane/mscfb v1.0.3
 )
+
+require github.com/richardlehane/msoleps v1.0.1 // indirect


### PR DESCRIPTION
This will require you to create a Github release manually when you want to deliver changes.
By using:
- https://github.com/lorenz/winsysroot/releases/new
- Press "select tag" -> "create new tag" -> insert a tag string, it should be the release version, e.g. `0.0.2`
- Then press the "Publish Release" button

Then the CI will run, build your binaries for all 6 variants and attach them to the release.
See https://github.com/ArchangelX360/winsysroot/releases/tag/0.0.2


Closes #2